### PR TITLE
Corrects bug where dots became squared before rounding when sliding

### DIFF
--- a/FlexiblePageControl/FlexiblePageControl.swift
+++ b/FlexiblePageControl/FlexiblePageControl.swift
@@ -406,9 +406,9 @@ private class ItemView: UIView {
             _size = CGSize.zero
         }
 
-        dotView.layer.cornerRadius = _size.height / 2.0
 
         UIView.animate(withDuration: animateDuration, animations: { [unowned self] in
+            self.dotView.layer.cornerRadius = _size.height / 2.0
             self.dotView.layer.bounds.size = _size
         })
     }


### PR DESCRIPTION
`cornerRadius`was not animated so this created a square defect on the dots when moving `scrollView`

Before

<img width="86" alt="Screenshot 2019-03-14 at 11 51 49" src="https://user-images.githubusercontent.com/14952286/54354966-cb60f300-464f-11e9-9eb2-af2695450837.png">

After
<img width="96" alt="Screenshot 2019-03-14 at 11 54 30" src="https://user-images.githubusercontent.com/14952286/54355097-2397f500-4650-11e9-9bf2-675b2d81b6ce.png">