### PR TITLE
fixes ScrollViews layout.

### DIFF
--- a/FlexiblePageControl/FlexiblePageControl.swift
+++ b/FlexiblePageControl/FlexiblePageControl.swift
@@ -178,9 +178,8 @@ public class FlexiblePageControl: UIView {
         items.forEach { scrollView.addSubview($0) }
 
         let size: CGSize = .init(width: itemSize * CGFloat(displayCount), height: itemSize)
-        let frame: CGRect = .init(origin: .zero, size: size)
 
-        scrollView.frame = frame
+        scrollView.bounds.size = size
 
         if displayCount < numberOfPages {
             scrollView.contentInset = .init(top: 0, left: itemSize * 2, bottom: 0, right: itemSize * 2)


### PR DESCRIPTION
はじめまして！

レイアウトが完了してから再度`numberOfPages`を変更するような処理をすると、Viewの位置がズレるようです。こちらを修正してみました。いかがでしょうか？

Demoで以下のようなコードを追加すると再現できます。

```
    override func viewDidAppear(_ animated: Bool) {
        super.viewDidAppear(animated)
        pageControl1.numberOfPages = 10
        pageControl2.numberOfPages = 10
    }
```

<img width="300" src="https://user-images.githubusercontent.com/2742732/54486436-b7c1c080-48cb-11e9-9787-73e8c101d494.png"/>

scrollView.frameを変更せず、bounds.sizeを変更することで位置を変えずに大きさだけ変更するようにしました。

ページ数を都度変えるような実装もあるかと思いますので、ご確認よろしくお願いいたします 🙇 