### PR TITLE
Make FlexiblePageControl properties customizable via UIAppearance

### DIFF
--- a/FlexiblePageControl/FlexiblePageControl.swift
+++ b/FlexiblePageControl/FlexiblePageControl.swift
@@ -42,7 +42,8 @@ public class FlexiblePageControl: UIView {
         self.config = config
         
         invalidateIntrinsicContentSize()
-
+		
+		displayCount = min(config.displayCount, numberOfPages)
         update(currentPage: currentPage, config: config)
     }
 

--- a/FlexiblePageControl/FlexiblePageControl.swift
+++ b/FlexiblePageControl/FlexiblePageControl.swift
@@ -12,7 +12,7 @@ public class FlexiblePageControl: UIView {
 
     // MARK: public
     
-    public struct Config {
+    @objc public class Config: NSObject {
         
         public var displayCount: Int
         public var dotSize: CGFloat
@@ -37,7 +37,7 @@ public class FlexiblePageControl: UIView {
     
     private var config = Config()
 
-    public func setConfig(_ config: Config) {
+    @objc dynamic public func setConfig(_ config: Config) {
 
         self.config = config
         
@@ -67,19 +67,19 @@ public class FlexiblePageControl: UIView {
         }
     }
 
-    public var pageIndicatorTintColor: UIColor = UIColor(red: 0.86, green: 0.86, blue: 0.86, alpha: 1.00) {
+    @objc dynamic public var pageIndicatorTintColor: UIColor = UIColor(red: 0.86, green: 0.86, blue: 0.86, alpha: 1.00) {
         didSet {
             updateDotColor(currentPage: currentPage)
         }
     }
 
-    public var currentPageIndicatorTintColor: UIColor = UIColor(red: 0.32, green: 0.59, blue: 0.91, alpha: 1.00) {
+    @objc dynamic public var currentPageIndicatorTintColor: UIColor = UIColor(red: 0.32, green: 0.59, blue: 0.91, alpha: 1.00) {
         didSet {
             updateDotColor(currentPage: currentPage)
         }
     }
 
-    public var animateDuration: TimeInterval = 0.3
+    @objc dynamic public var animateDuration: TimeInterval = 0.3
 
     public var hidesForSinglePage: Bool = false {
         didSet {


### PR DESCRIPTION
The proposed changes allow `FlexiblePageControl` to be customizable via `UIAppearance`, for instance:
````
let config = FlexiblePageControl.Config(
	displayCount: 5,
	dotSize: 6,
	dotSpace: 4,
	smallDotSizeRatio: 0.5,
	mediumDotSizeRatio: 0.7
)
FlexiblePageControl.appearance().pageIndicatorTintColor = UIColor.systemGray
FlexiblePageControl.appearance().currentPageIndicatorTintColor = UIColor.systemBlue
FlexiblePageControl.appearance().setConfig(config)
````

- Add `@objc dynamic` to `setConfig()`, `pageIndicatorTintColor`, `currentPageIndicatorTintColor`, `animateDuration`
- Make `Config` `class` and inherit from `NSObject`.